### PR TITLE
feat: 채팅 내역 조회 바텀시트 구현 및 API 연동

### DIFF
--- a/src/app/api/endpoints/chats.js
+++ b/src/app/api/endpoints/chats.js
@@ -11,3 +11,35 @@ export const fetchChats = async () => {
   const response = await apiClient.get(API_CONFIG.ENDPOINTS.CHATS);
   return response.data.data;
 };
+
+/**
+ * Fetch chat messages for a specific chatroom (cursor-based pagination)
+ * @param {number} chatroomId - Chatroom ID
+ * @param {string | null} cursor - Cursor value (timestamp|messageId format)
+ * @param {number} size - Page size (default: 20)
+ * @returns {Promise<{chats: Array, before: string | null, next: string | null}>}
+ * @throws {Error} 401 if not authenticated, 400 if invalid cursor/size
+ */
+export const fetchChatMessages = async (chatroomId, cursor = null, size = 20) => {
+  const params = { size };
+  if (cursor) {
+    params.after = cursor;
+  }
+
+  const response = await apiClient.get(API_CONFIG.ENDPOINTS.CHAT_MESSAGES(chatroomId), {
+    params,
+  });
+  return response.data.data;
+};
+
+/**
+ * Send a message to a chatroom
+ * TODO: Implement after POST API spec is provided
+ * @param {number} chatroomId - Chatroom ID
+ * @param {object} payload - Message payload (text, files, etc.)
+ * @returns {Promise<object>} Created message object
+ */
+export const sendChatMessage = async (chatroomId, payload) => {
+  // TODO: Implement after POST /chats/{chatroomId} spec is provided
+  throw new Error('POST /chats/{chatroomId} API spec not yet provided');
+};

--- a/src/app/components/features/ChatRoomListSheet.jsx
+++ b/src/app/components/features/ChatRoomListSheet.jsx
@@ -1,21 +1,165 @@
-import { useState } from 'react';
-import { MessageSquare, Loader2 } from 'lucide-react';
+import { useState, useRef, useEffect, useCallback } from 'react';
+import {
+  MessageSquare,
+  Loader2,
+  ChevronLeft,
+  X,
+  Send,
+  ChevronDown,
+} from 'lucide-react';
 import { Drawer } from 'vaul';
-import { useChats } from '@/app/hooks/queries/useChatQueries';
-import { formatKoreanTimestamp } from '@/app/lib/utils';
+import { useChats, useChatMessages } from '@/app/hooks/queries/useChatQueries';
+import { useSendMessage } from '@/app/hooks/mutations/useChatMutations';
+import { useUserProfile } from '@/app/hooks/queries/useUserQuery';
+import {
+  formatKoreanTimestamp,
+  formatMessageTime,
+  formatMessageDate,
+  getLocalDate,
+} from '@/app/lib/utils';
 
 export function ChatRoomListSheet() {
   const [isOpen, setIsOpen] = useState(false);
+  const [viewMode, setViewMode] = useState('list'); // 'list' | 'messages'
+  const [selectedRoomId, setSelectedRoomId] = useState(null);
+  const [selectedRoomName, setSelectedRoomName] = useState('');
+
+  const [inputText, setInputText] = useState('');
+  const scrollContainerRef = useRef(null);
+  const [isNearBottom, setIsNearBottom] = useState(true);
 
   const { data: chatRooms = [], isLoading, isError, error } = useChats();
 
+  const { data: userProfile } = useUserProfile();
+  const currentUserId = userProfile?.id;
+
+  const {
+    data: messagesData,
+    isLoading: isLoadingMessages,
+    isError: isMessagesError,
+    error: messagesError,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useChatMessages(viewMode === 'messages' ? selectedRoomId : null);
+
+  const { mutate: sendMessage, isPending: isSending } =
+    useSendMessage(selectedRoomId);
+
+  const messages = messagesData?.pages?.flatMap((page) => page.chats) || [];
+
   /**
    * Handle chat room card click
-   * TODO: Implement navigation to specific chat room
+   * Switches to message view for the selected room
    * @param {number} roomId - Chat room ID
+   * @param {string} roomName - Chat room name
    */
-  const handleRoomClick = () => {
-    setIsOpen(false);
+  const handleRoomClick = (roomId, roomName) => {
+    setSelectedRoomId(roomId);
+    setSelectedRoomName(roomName);
+    setViewMode('messages');
+  };
+
+  /**
+   * Handle back button click
+   * Returns to chat room list view
+   */
+  const handleBackToList = () => {
+    setViewMode('list');
+    setSelectedRoomId(null);
+    setSelectedRoomName('');
+    setInputText('');
+    setIsNearBottom(true);
+  };
+
+  // Auto-scroll to bottom on initial load and new messages
+  useEffect(() => {
+    if (
+      viewMode === 'messages' &&
+      messages.length > 0 &&
+      scrollContainerRef.current &&
+      isNearBottom
+    ) {
+      scrollContainerRef.current.scrollTop =
+        scrollContainerRef.current.scrollHeight;
+    }
+  }, [viewMode, messages.length, isNearBottom]);
+
+  // Detect scroll position for infinite scroll
+  const handleScroll = useCallback(() => {
+    if (!scrollContainerRef.current) return;
+
+    const { scrollTop, scrollHeight, clientHeight } =
+      scrollContainerRef.current;
+
+    // Check if near top (load more)
+    if (scrollTop < 100 && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+
+    // Check if near bottom (for auto-scroll logic)
+    const isBottom = scrollHeight - scrollTop - clientHeight < 100;
+    setIsNearBottom(isBottom);
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  // Handle send message
+  const handleSend = () => {
+    if (!inputText.trim() || isSending) return;
+
+    sendMessage(
+      { message: inputText },
+      {
+        onSuccess: () => {
+          setInputText('');
+          setTimeout(() => {
+            if (scrollContainerRef.current) {
+              scrollContainerRef.current.scrollTop =
+                scrollContainerRef.current.scrollHeight;
+            }
+          }, 100);
+        },
+      }
+    );
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.nativeEvent.isComposing) return;
+
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  /**
+   * Determine if sender label should be shown
+   * @param {object} msg - Current message
+   * @param {number} index - Message index
+   * @param {Array} messages - All messages
+   * @param {number} currentUserId - Current user ID
+   * @returns {boolean}
+   */
+  const shouldShowSenderLabel = (msg, index, messages, currentUserId) => {
+    if (msg.sender === currentUserId) return false;
+
+    if (index === 0) return true;
+
+    return messages[index - 1].sender !== msg.sender;
+  };
+
+  /**
+   * Determine if date divider should be shown before this message
+   * @param {object} msg - Current message
+   * @param {number} index - Message index
+   * @param {Array} messages - All messages
+   * @returns {boolean}
+   */
+  const shouldShowDateDivider = (msg, index, messages) => {
+    if (index === 0) return true;
+
+    const currentDate = getLocalDate(msg.sendAt);
+    const prevDate = getLocalDate(messages[index - 1].sendAt);
+    return currentDate !== prevDate;
   };
 
   return (
@@ -39,66 +183,282 @@ export function ChatRoomListSheet() {
           {/* Drag handle */}
           <div className="mx-auto w-12 h-1.5 flex-shrink-0 rounded-full bg-gray-300 my-4" />
 
-          {/* Header */}
-          <div className="px-8 py-2">
-            <Drawer.Title className="text-base font-semibold">
-              채팅방 목록
-            </Drawer.Title>
-          </div>
+          {/* Header - Conditional based on view mode */}
+          {viewMode === 'list' ? (
+            <div className="px-8 py-2">
+              <Drawer.Title className="text-base font-semibold">
+                채팅방 목록
+              </Drawer.Title>
+            </div>
+          ) : (
+            <div className="px-8 py-2 border-b border-gray-200 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleBackToList}
+                  className="p-2 hover:bg-gray-100 rounded-full transition-colors -ml-2"
+                  aria-label="채팅방 목록으로 돌아가기"
+                >
+                  <ChevronLeft className="w-5 h-5 text-gray-700" />
+                </button>
+                <Drawer.Title className="text-base font-semibold">
+                  {selectedRoomName}
+                </Drawer.Title>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+                aria-label="닫기"
+              >
+                <X className="w-5 h-5 text-gray-700" />
+              </button>
+            </div>
+          )}
 
-          {/* Content Area with Loading/Error States */}
-          <div className="flex-1 overflow-y-auto px-5 py-4">
-            {isLoading ? (
-              <div className="flex flex-col items-center justify-center py-12">
-                <Loader2 className="w-8 h-8 animate-spin text-primary mb-3" />
-                <p className="text-sm text-gray-500">채팅방 불러오는 중...</p>
-              </div>
-            ) : isError ? (
-              <div className="flex flex-col items-center justify-center py-12">
-                <p className="text-sm text-gray-600 mb-2">
-                  채팅방을 불러올 수 없습니다
-                </p>
-                <p className="text-xs text-gray-500">
-                  {error?.response?.status === 401
-                    ? '로그인이 필요합니다'
-                    : '잠시 후 다시 시도해주세요'}
-                </p>
-              </div>
-            ) : chatRooms.length === 0 ? (
-              <div className="flex flex-col items-center justify-center py-12">
-                <p className="text-sm text-gray-500">
-                  생성된 채팅방이 없습니다
-                </p>
-              </div>
-            ) : (
-              // Room List
-              <div className="space-y-3">
-                {chatRooms.map((room) => (
-                  <button
-                    key={room.id}
-                    type="button"
-                    onClick={() => handleRoomClick(room.id)}
-                    className="w-full text-left p-4 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors"
-                  >
-                    {/* Header: Room name and timestamp */}
-                    <div className="flex items-start justify-between mb-1">
-                      <h4 className="font-semibold text-base">{room.name}</h4>
-                      {room.lastUpdatedAt && (
-                        <span className="text-xs text-gray-500 whitespace-nowrap ml-2">
-                          {formatKoreanTimestamp(room.lastUpdatedAt)}
-                        </span>
-                      )}
-                    </div>
-
-                    {/* Last message preview */}
-                    <p className="text-sm text-gray-600 truncate">
-                      {room.lastMessage || '첫 메시지를 보내보세요!'}
+          {/* Content Area */}
+          {viewMode === 'list' ? (
+            // Chat Room List View
+            <div className="flex-1 overflow-y-auto px-5 py-4">
+              {isLoading ? (
+                <div className="flex flex-col items-center justify-center py-12">
+                  <Loader2 className="w-8 h-8 animate-spin text-primary mb-3" />
+                  <p className="text-sm text-gray-500">채팅방 불러오는 중...</p>
+                </div>
+              ) : isError ? (
+                <div className="flex flex-col items-center justify-center py-12">
+                  <p className="text-sm text-gray-600 mb-2">
+                    채팅방을 불러올 수 없습니다
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    {error?.response?.status === 401
+                      ? '로그인이 필요합니다'
+                      : '잠시 후 다시 시도해주세요'}
+                  </p>
+                </div>
+              ) : chatRooms.length === 0 ? (
+                <div className="flex flex-col items-center justify-center py-12">
+                  <p className="text-sm text-gray-500">
+                    생성된 채팅방이 없습니다
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {chatRooms.map((room) => (
+                    <button
+                      key={room.id}
+                      type="button"
+                      onClick={() => handleRoomClick(room.id, room.name)}
+                      className="w-full text-left p-4 rounded-lg border border-gray-200 hover:bg-gray-50 transition-colors"
+                    >
+                      <div className="flex items-start justify-between mb-1">
+                        <h4 className="font-semibold text-base">{room.name}</h4>
+                        {room.lastUpdatedAt && (
+                          <span className="text-xs text-gray-500 whitespace-nowrap ml-2">
+                            {formatKoreanTimestamp(room.lastUpdatedAt)}
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-sm text-gray-600 truncate">
+                        {room.lastMessage || '첫 메시지를 보내보세요!'}
+                      </p>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          ) : (
+            // Message History View
+            <>
+              {/* Message List Area */}
+              <div
+                ref={scrollContainerRef}
+                className="flex-1 overflow-y-auto px-5 py-4"
+                onScroll={handleScroll}
+              >
+                {isLoadingMessages ? (
+                  <div className="flex flex-col items-center justify-center h-full">
+                    <Loader2 className="w-8 h-8 animate-spin text-primary mb-3" />
+                    <p className="text-sm text-gray-500">
+                      메시지 불러오는 중...
                     </p>
-                  </button>
-                ))}
+                  </div>
+                ) : isMessagesError ? (
+                  <div className="flex flex-col items-center justify-center h-full">
+                    <p className="text-sm text-gray-600 mb-2">
+                      메시지를 불러올 수 없습니다
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {messagesError?.response?.status === 401
+                        ? '로그인이 필요합니다'
+                        : '잠시 후 다시 시도해주세요'}
+                    </p>
+                  </div>
+                ) : messages.length === 0 ? (
+                  <div className="flex flex-col items-center justify-center h-full">
+                    <p className="text-sm text-gray-500">
+                      아직 메시지가 없습니다
+                    </p>
+                  </div>
+                ) : (
+                  <>
+                    {/* Infinite Scroll Load Indicator */}
+                    {isFetchingNextPage && (
+                      <div className="flex items-center justify-center py-3">
+                        <Loader2 className="w-5 h-5 animate-spin text-primary mr-2" />
+                        <p className="text-xs text-gray-500">
+                          이전 메시지 불러오는 중...
+                        </p>
+                      </div>
+                    )}
+
+                    {/* Message List */}
+                    <div className="space-y-3">
+                      {messages.map((msg, index) => {
+                        const isCurrentUser = msg.sender === currentUserId;
+                        const timeString = formatMessageTime(msg.sendAt);
+                        const showSenderLabel = shouldShowSenderLabel(
+                          msg,
+                          index,
+                          messages,
+                          currentUserId
+                        );
+                        const showDateDivider = shouldShowDateDivider(
+                          msg,
+                          index,
+                          messages
+                        );
+
+                        return (
+                          <div key={msg.id}>
+                            {/* Date Divider */}
+                            {showDateDivider && (
+                              <div className="flex justify-center my-4">
+                                <div className="bg-gray-100 text-gray-600 text-xs px-3 py-1 rounded-full">
+                                  {formatMessageDate(msg.sendAt)}
+                                </div>
+                              </div>
+                            )}
+
+                            {/* Sender Label */}
+                            {showSenderLabel && (
+                              <div className="text-xs text-gray-500 mb-1 ml-1">
+                                익명{msg.senderNumber}
+                              </div>
+                            )}
+
+                            {/* Message Container */}
+                            <div
+                              className={`flex items-end gap-2 ${isCurrentUser ? 'justify-end' : 'justify-start'}`}
+                            >
+                              {/* Timestamp (left side for current user) */}
+                              {isCurrentUser && timeString && (
+                                <span className="text-xs text-gray-500 mb-1">
+                                  {timeString}
+                                </span>
+                              )}
+
+                              {/* Message Bubble */}
+                              <div className="max-w-[70%]">
+                                <div
+                                  className={`rounded-2xl px-4 py-2 ${
+                                    isCurrentUser
+                                      ? 'bg-primary text-white rounded-br-sm'
+                                      : 'bg-gray-100 text-gray-900 rounded-bl-sm'
+                                  }`}
+                                >
+                                  {msg.message && (
+                                    <p className="text-sm">{msg.message}</p>
+                                  )}
+
+                                  {/* File Attachments */}
+                                  {msg.files?.length > 0 && (
+                                    <div className="mt-2 space-y-2">
+                                      {msg.files.map((file) => (
+                                        <div key={file.id}>
+                                          {file.fileType === 'IMAGE' ? (
+                                            <img
+                                              src={file.fileUrl}
+                                              alt="첨부 이미지"
+                                              className="rounded-lg max-w-full"
+                                            />
+                                          ) : (
+                                            <a
+                                              href={file.fileUrl}
+                                              target="_blank"
+                                              rel="noopener noreferrer"
+                                              className="text-xs underline"
+                                            >
+                                              첨부파일 보기
+                                            </a>
+                                          )}
+                                        </div>
+                                      ))}
+                                    </div>
+                                  )}
+                                </div>
+                              </div>
+
+                              {/* Timestamp (right side for other users) */}
+                              {!isCurrentUser && timeString && (
+                                <span className="text-xs text-gray-500 mb-1">
+                                  {timeString}
+                                </span>
+                              )}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </>
+                )}
               </div>
-            )}
-          </div>
+
+              {/* Scroll to Bottom Button (shown when not near bottom) */}
+              {!isNearBottom && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (scrollContainerRef.current) {
+                      scrollContainerRef.current.scrollTop =
+                        scrollContainerRef.current.scrollHeight;
+                    }
+                  }}
+                  className="absolute bottom-24 right-8 bg-white border border-gray-300 rounded-full p-2 shadow-lg hover:bg-gray-50 transition-colors"
+                  aria-label="맨 아래로 스크롤"
+                >
+                  <ChevronDown className="w-5 h-5 text-gray-700" />
+                </button>
+              )}
+
+              {/* Input Area */}
+              <div className="border-t border-gray-200 px-5 py-4">
+                <div className="flex items-end gap-3">
+                  <textarea
+                    value={inputText}
+                    onChange={(e) => setInputText(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    placeholder="메시지를 입력하세요..."
+                    className="flex-1 resize-none border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                    rows={1}
+                    maxLength={500}
+                  />
+                  <button
+                    type="button"
+                    onClick={handleSend}
+                    disabled={!inputText.trim() || isSending}
+                    className="bg-primary text-white rounded-lg px-4 py-2 hover:bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+                  >
+                    {isSending ? (
+                      <Loader2 className="w-5 h-5 animate-spin" />
+                    ) : (
+                      <Send className="w-5 h-5" />
+                    )}
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
         </Drawer.Content>
       </Drawer.Portal>
     </Drawer.Root>

--- a/src/app/hooks/mutations/useChatMutations.js
+++ b/src/app/hooks/mutations/useChatMutations.js
@@ -1,0 +1,32 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { sendChatMessage } from '@/app/api/endpoints/chats';
+
+/**
+ * Send a message to a chatroom
+ * @param {number} chatroomId - Chatroom ID
+ * @returns {import('@tanstack/react-query').UseMutationResult}
+ */
+export function useSendMessage(chatroomId) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload) => sendChatMessage(chatroomId, payload),
+    onSuccess: (newMessage) => {
+      queryClient.setQueryData(['chatMessages', chatroomId], (oldData) => {
+        if (!oldData) return oldData;
+
+        const updatedPages = [...oldData.pages];
+        const lastPage = updatedPages[updatedPages.length - 1];
+
+        updatedPages[updatedPages.length - 1] = {
+          ...lastPage,
+          chats: [...lastPage.chats, newMessage],
+        };
+
+        return { ...oldData, pages: updatedPages };
+      });
+
+      queryClient.invalidateQueries(['chats']);
+    },
+  });
+}

--- a/src/app/hooks/queries/useChatQueries.js
+++ b/src/app/hooks/queries/useChatQueries.js
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-import { fetchChats } from '@/app/api/endpoints/chats';
+import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
+import { fetchChats, fetchChatMessages } from '@/app/api/endpoints/chats';
 
 /**
  * Fetch all chatrooms
@@ -12,5 +12,26 @@ export function useChats() {
     staleTime: 0,
     gcTime: 1000 * 60 * 5, // 5분
     refetchInterval: 3000, // 3초마다 메시지 재확인
+  });
+}
+
+/**
+ * Fetch chat messages with infinite scroll (cursor-based pagination)
+ * Only fetches on initial render and when scrolling up (fetchNextPage).
+ * @param {number | null} chatroomId - Chatroom ID
+ * @returns {import('@tanstack/react-query').UseInfiniteQueryResult}
+ */
+export function useChatMessages(chatroomId) {
+  return useInfiniteQuery({
+    queryKey: ['chatMessages', chatroomId],
+    queryFn: ({ pageParam = null }) => fetchChatMessages(chatroomId, pageParam),
+    getNextPageParam: (lastPage) => lastPage.next || undefined,
+    getPreviousPageParam: (firstPage) => firstPage.before || undefined,
+    enabled: !!chatroomId,
+    staleTime: Infinity,
+    gcTime: 1000 * 60 * 5,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 }

--- a/src/app/lib/utils.js
+++ b/src/app/lib/utils.js
@@ -73,6 +73,66 @@ export function formatKoreanTimestamp(isoTimestamp) {
 }
 
 /**
+ * Format ISO timestamp to time-only Korean format
+ * Used for chat message timestamps (no date, only time)
+ * @param {string | null} isoTimestamp - ISO 8601 timestamp
+ * @returns {string} "오전 10:30" or "오후 03:05" format (empty string if invalid)
+ */
+export function formatMessageTime(isoTimestamp) {
+  if (!isoTimestamp) return '';
+
+  try {
+    const date = new Date(isoTimestamp);
+    const hours = date.getHours();
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+
+    const period = hours < 12 ? '오전' : '오후';
+    const displayHours = hours % 12 || 12;
+
+    return `${period} ${displayHours}:${minutes}`;
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Format ISO timestamp to Korean date format (for date dividers)
+ * @param {string | null} isoTimestamp - ISO 8601 timestamp
+ * @returns {string} "YYYY년 M월 D일" format (empty string if invalid)
+ */
+export function formatMessageDate(isoTimestamp) {
+  if (!isoTimestamp) return '';
+
+  try {
+    const date = new Date(isoTimestamp);
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1; // No padding
+    const day = date.getDate(); // No padding
+
+    return `${year}년 ${month}월 ${day}일`;
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Extract local date string from ISO timestamp (YYYY-M-D)
+ * Used for date comparison to determine when to show date dividers
+ * @param {string | null} isoTimestamp - ISO 8601 timestamp
+ * @returns {string} "YYYY-M-D" format (empty string if invalid)
+ */
+export function getLocalDate(isoTimestamp) {
+  if (!isoTimestamp) return '';
+
+  try {
+    const date = new Date(isoTimestamp);
+    return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+  } catch {
+    return '';
+  }
+}
+
+/**
  * 이모티콘 존재 여부를 검증합니다.
  */
 const EMOJI_REGEX = /\p{Emoji_Presentation}/gu;


### PR DESCRIPTION
### Description

채팅방 내 채팅 내역을 조회하는 바텀시트를 구현하고 API를 연동합니다.

### Related Issues

- Resolves #18 

### Changes Made

1. 채팅방 목록을 조회하는 바텀시트에서 즉시 채팅 내역을 조회할 수 있게 구현
2. 전송하고자 하는 메시지 입력 창, 전송 버튼을 포함한 전체 채팅 내역 바텀 시트 UI 구현
3. 채팅 내역 조회 API 연동
    3-1. 처음 1회 및 스크롤 시에만 불러오도록 구현

### Screenshots or Video

<img width="500" alt="Screenshot 2026-01-27 at 11 57 55" src="https://github.com/user-attachments/assets/e48eaa45-8605-43f8-81fa-089812871461" />


### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.

### Additional Notes

- 웹소켓 연동 예정이므로 채팅 내역 조회를 폴링 방식으로 구현하지 않음, 새 메시지는 웹소켓 연결 후 웹소켓 통신으로 받을 예정
- 채팅방 Virtual List를 통한 최적화 예정