### PR TITLE
fix: CI/CD 설정에서 actions 권한 추가

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -19,6 +19,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 


### PR DESCRIPTION
### Description

cicd 수동배포 실패 오류 수정
