### PR TITLE
fix: CI/CD에서 GITHUB_TOKEN 추가

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -232,6 +232,7 @@ jobs:
           path: dist
           repository: ${{ github.repository }}
           run-id: ${{ inputs.ci_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pack dist
         shell: bash


### PR DESCRIPTION
### Description
cicd 수동 워크플로우 artifacts 공유를 위한 토큰 추가