### PR TITLE
feat: 이미지 삭제 버튼 추가

### DIFF
--- a/src/app/pages/SettingsPage.jsx
+++ b/src/app/pages/SettingsPage.jsx
@@ -386,6 +386,26 @@ export function SettingsPage() {
     [profilePreviewUrl]
   );
 
+  /**
+   * Removes the profile image (both new preview and existing server image)
+   * Only works in edit mode
+   */
+  const removeProfileImage = useCallback(() => {
+    // Revoke new preview URL if exists
+    if (profilePreviewUrl) {
+      URL.revokeObjectURL(profilePreviewUrl);
+    }
+    // Clear new file state
+    setProfileFile(null);
+    setProfilePreviewUrl(null);
+
+    // Clear existing server image from editData
+    setEditData((prev) => ({
+      ...prev,
+      profileImage: null,
+    }));
+  }, [profilePreviewUrl]);
+
   const handleEdit = useCallback(() => {
     if (!profileData) return;
     const positionName =
@@ -700,6 +720,15 @@ export function SettingsPage() {
                   onClick={() => profileFileInputRef.current?.click()}
                 >
                   프로필 사진 변경
+                </button>
+              )}
+              {isEditing && (profilePreviewUrl || editData.profileImage) && (
+                <button
+                  type="button"
+                  className="text-sm text-gray-500"
+                  onClick={removeProfileImage}
+                >
+                  이미지 삭제
                 </button>
               )}
             </div>

--- a/src/app/pages/auth/SignupPage.jsx
+++ b/src/app/pages/auth/SignupPage.jsx
@@ -494,6 +494,17 @@ Commit-me 서비스는 「개인정보보호법」 등 관련 법령에 따라 �
     [profilePreviewUrl]
   );
 
+  /**
+   * Removes the selected profile image and cleans up the preview URL
+   */
+  const removeProfileImage = useCallback(() => {
+    if (profilePreviewUrl) {
+      URL.revokeObjectURL(profilePreviewUrl);
+    }
+    setProfileFile(null);
+    setProfilePreviewUrl(null);
+  }, [profilePreviewUrl]);
+
   const handleSubmit = useCallback(
     async (e) => {
       e.preventDefault();
@@ -635,6 +646,15 @@ Commit-me 서비스는 「개인정보보호법」 등 관련 법령에 따라 �
             >
               사진 업로드 (선택)
             </button>
+            {profilePreviewUrl && (
+              <button
+                type="button"
+                className="text-sm text-gray-500"
+                onClick={removeProfileImage}
+              >
+                이미지 삭제
+              </button>
+            )}
           </div>
 
           {/* Form Fields */}


### PR DESCRIPTION
### Description

회원가입/설정 페이지에서 이미지가 존재하는 경우 이미지 삭제 버튼을 추가하였습니다.

### Related Issues

- Resolves #91 

### Changes Made

1. 회원가입 및 설정 페이지에서 이미지가 존재하는 경우 이미지 삭제 버튼을 클릭하여 이미지를 삭제할 수 있습니다.

### Screenshots or Video

<img width="500" alt="Screenshot 2026-02-07 at 21 47 27" src="https://github.com/user-attachments/assets/3b235a80-c3cf-4fb5-98a0-37f68c6fe83f" />

### Testing

iOS/Chrome/Localhost

### Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.